### PR TITLE
RFC: Polling workflow

### DIFF
--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow.sln
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElsaGuides.PollingWorkflow", "ElsaGuides.PollingWorkflow\ElsaGuides.PollingWorkflow.csproj", "{7BDBF284-843D-440F-B15B-FBF57E8DCA79}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7BDBF284-843D-440F-B15B-FBF57E8DCA79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BDBF284-843D-440F-B15B-FBF57E8DCA79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BDBF284-843D-440F-B15B-FBF57E8DCA79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BDBF284-843D-440F-B15B-FBF57E8DCA79}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Controllers/TestController.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Controllers/TestController.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Elsa.Services;
+using Elsa.Services.Models;
+using ElsaGuides.PollingWorkflow.Workflow;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ElsaGuides.PollingWorkflow.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class TestController : ControllerBase
+    {
+        private readonly IBuildsAndStartsWorkflow _workflow;
+        private readonly IWorkflowLaunchpad _workflowLaunchpad;
+
+        public TestController(IBuildsAndStartsWorkflow workflow, IWorkflowLaunchpad workflowLaunchpad)
+        {
+            _workflow = workflow;
+            _workflowLaunchpad = workflowLaunchpad;
+        }
+
+        [HttpPost("start")]
+        public async Task<IActionResult> Start()
+        {
+            var correlationId = Guid.NewGuid().ToString();
+
+            await _workflow.BuildAndStartWorkflowAsync<Workflow.PollingWorkflow>(correlationId: correlationId);
+            
+            return Ok(correlationId);
+        }
+        
+        [HttpPost("abort/{id}")]
+        public async Task<IActionResult> Abort(string id)
+        {
+            var query = new WorkflowsQuery(nameof(AbortActivity), new AbortActivityBookmark(), id);
+            
+            await _workflowLaunchpad.CollectAndDispatchWorkflowsAsync(query);
+
+            return NoContent();
+        }
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow.csproj
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Elsa" Version="2.4.0.1" />
+        <PackageReference Include="Elsa.Abstractions" Version="2.4.0.1" />
+        <PackageReference Include="Elsa.Activities.Temporal.Quartz" Version="2.4.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.1" NoWarn="NU1605" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.1" NoWarn="NU1605" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    </ItemGroup>
+
+</Project>

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Program.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Program.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace ElsaGuides.PollingWorkflow
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder => { webBuilder.UseStartup<Startup>(); });
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Startup.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Startup.cs
@@ -1,0 +1,60 @@
+using Elsa;
+using ElsaGuides.PollingWorkflow.Workflow;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.OpenApi.Models;
+
+namespace ElsaGuides.PollingWorkflow
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddHttpClient();
+            
+            services.AddElsa(x => x
+                .AddQuartzTemporalActivities()
+                .AddActivitiesFrom<Workflow.PollingWorkflow>()
+                .AddWorkflow<Workflow.PollingWorkflow>()
+            );
+            
+            services.AddBookmarkProvider<AbortActivityBookmarkProvider>();
+            
+            services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "ElsaGuides.PollingWorkflow", Version = "v1" });
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "ElsaGuides.PollingWorkflow v1"));
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+        }
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/AbortActivity.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/AbortActivity.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Elsa.ActivityResults;
+using Elsa.Services;
+using Elsa.Services.Models;
+
+namespace ElsaGuides.PollingWorkflow.Workflow
+{
+    public class AbortActivity : Activity
+    {
+        protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
+        {
+            return Suspend();
+        }
+
+
+        protected override async ValueTask<IActivityExecutionResult> OnResumeAsync(ActivityExecutionContext context)
+        {
+            return Done();
+        }
+    }
+
+    public class AbortActivityBookmark : IBookmark { }
+    
+    public class AbortActivityBookmarkProvider : BookmarkProvider<AbortActivityBookmark, AbortActivity> 
+    {
+        public override IEnumerable<BookmarkResult> GetBookmarks(BookmarkProviderContext<AbortActivity> context)
+        {
+            return new[] {Result(new AbortActivityBookmark())};
+        }
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/PollingActivity.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/PollingActivity.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Elsa.Activities.Temporal.Common.ActivityResults;
+using Elsa.ActivityResults;
+using Elsa.Services;
+using Elsa.Services.Models;
+using NodaTime;
+
+namespace ElsaGuides.PollingWorkflow.Workflow
+{
+    public class PollingActivity : Activity
+    {
+        private readonly IClock _clock;
+        private readonly HttpClient _httpClient;
+
+        public PollingActivity(IClock clock, HttpClient httpClient)
+        {
+            _clock = clock;
+            _httpClient = httpClient;
+        }
+
+        private async ValueTask<IActivityExecutionResult> Execute(ActivityExecutionContext context)
+        {
+            var result = await _httpClient.GetAsync("http://www.randomnumberapi.com/api/v1.0/random?min=0&max=10&count=1");
+            var content = await result.Content.ReadAsStringAsync();
+            var number = JsonSerializer.Deserialize<int[]>(content)?.FirstOrDefault() ?? 0;
+
+            Console.WriteLine($"Polling workflow with correlation id: {context.CorrelationId} number: {number}");
+
+            if (number == 5)
+            {
+                return Done();
+            }
+            
+            return Combine(Suspend(), new ScheduleWorkflowResult(_clock.GetCurrentInstant().Plus(Duration.FromSeconds(2))));
+        }
+        
+        protected override async ValueTask<IActivityExecutionResult> OnExecuteAsync(ActivityExecutionContext context)
+            => await Execute(context);
+
+        protected override async ValueTask<IActivityExecutionResult> OnResumeAsync(ActivityExecutionContext context)
+            => await Execute(context);
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/PollingWorkflow.cs
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/Workflow/PollingWorkflow.cs
@@ -1,0 +1,27 @@
+using Elsa.Activities.ControlFlow;
+using Elsa.Builders;
+
+namespace ElsaGuides.PollingWorkflow.Workflow
+{
+    public class PollingWorkflow : IWorkflow
+    {
+        public void Build(IWorkflowBuilder builder)
+        {
+            builder
+                .Then<Fork>(fork => fork.WithBranches("abort", "poll"), fork =>
+                {
+                    fork
+                        .When("abort")
+                        .Then<AbortActivity>()
+                        .ThenNamed("join");
+
+                    fork
+                        .When("poll")
+                        .Then<PollingActivity>()
+                        .ThenNamed("join");
+
+                })
+                .Then<Join>(join => join.WithMode(Join.JoinMode.WaitAny)).WithName("join");
+        }
+    }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/appsettings.Development.json
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/appsettings.json
+++ b/src/ElsaGuides.PollingWorkflow/ElsaGuides.PollingWorkflow/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
I was investigating the a problem and couldn't find it in the guides so I came up with this solution and thought that it could be a topic under guides. But before writing the text I wanted to make sure that you think that it is an OK solution and that it would be a suitable topic for a guide?

The problem that I had was roughly this:

- First I make a call to an external service
- Then I have to poll that service every x hours and wait for a specific response. If I get the response I should proceed with the workflow.
- The workflow should also abort the poll on some events.

The solution uses a fork, one branch waits for the aborts and one makes the polls. The activity that makes the polls will reschedule itself if it dosn't get the result that it wants. In this example I make a call to an free random number api and waits for the number 5.

The guide would touch on these subjects:

- Programatically creating workflows
- Forks and joins
- Resume workflows
- Custom activities that reschedule itself.

What do you think should would it be an OK topic for a guide?