### PR TITLE
Updated .AddRemoteBackend to use the BackendApiConfig object

### DIFF
--- a/src/installation/elsa-studio/ElsaStudioBlazorServer/Program.cs
+++ b/src/installation/elsa-studio/ElsaStudioBlazorServer/Program.cs
@@ -22,9 +22,17 @@ builder.Services.AddServerSideBlazor(options =>
 // Register shell services and modules.
 builder.Services.AddCore();
 builder.Services.AddShell(options => configuration.GetSection("Shell").Bind(options));
-builder.Services.AddRemoteBackend(
-    elsaClient => elsaClient.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler),
-    options => configuration.GetSection("Backend").Bind(options));
+
+//load the backend configuration from the appsettings.json file
+var backendApiConfig = new BackendApiConfig
+{
+    ConfigureBackendOptions = options => builder.Configuration.GetSection("Backend").Bind(options),
+    ConfigureHttpClientBuilder = options => options.AuthenticationHandler = typeof(AuthenticatingApiHttpMessageHandler)
+};
+
+//set the remote backend that was loaded from the appsettings.json file
+builder.Services.AddRemoteBackend(backendApiConfig);
+
 builder.Services.AddLoginModule();
 builder.Services.AddDashboardModule();
 builder.Services.AddWorkflowsModule();


### PR DESCRIPTION
This guide uses two parameters to pass into the AddRemoteBackend call, but the new AddRemoteBackend only requires one parameter so this call was failing and cause a compilation error.

I updated the code to load the configuration into a BackendApiConfig object from the appsettings.json file, then subsequently passing that object into the AddRemoteBackend call. This is similar to the example code in elsa-workflows/elsa-core · src/apps/ElsaStudioWebAssembly/Program.cs but looks like the guide didn't get update to reflect this change.